### PR TITLE
Setting page width to 1300px

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,6 +132,7 @@ html_theme_options = {
         'github_repo': 'polyclonal',
         'github_banner': 'true',
         'travis_button': 'false',
+        'page_width': '1300px',
         'sidebar_width': '250px',
         }
 


### PR DESCRIPTION
The narrowness of the docs was driving me a bit batty:

![image](https://user-images.githubusercontent.com/112708/145708759-7d35f5a9-5258-480f-b607-1a6b6e040108.png)

This widens it like so:

![image](https://user-images.githubusercontent.com/112708/145708779-cf2e90b3-2b77-4ac5-bd90-65a087285aed.png)

It's probably "bad web design" but I find it a lot easier to read.

Just a suggestion. I can just build my own and be happy.