### PR TITLE
make `Polyclonal` fitting and harmonization errors more specific

### DIFF
--- a/polyclonal/polyclonal_collection.py
+++ b/polyclonal/polyclonal_collection.py
@@ -16,6 +16,7 @@ from multiprocessing import Pool
 import pandas as pd
 
 import polyclonal
+from polyclonal.polyclonal import PolyclonalFitError, PolyclonalHarmonizeError
 
 
 def create_bootstrap_sample(df, seed=0, group_by_col="concentration"):
@@ -97,7 +98,7 @@ def _fit_polyclonal_model_static(polyclonal_obj, **kwargs):
 
     A wrapper method for fitting models with `multiprocessing`.
     If scipy optimization fails, :class:Polyclonal objects will throw a
-    `RuntimeError`.
+    `PolyclonalFitError`.
 
     We catch this error and proceed with the program by returning `None` for the
     model that failed optimization.
@@ -116,7 +117,7 @@ def _fit_polyclonal_model_static(polyclonal_obj, **kwargs):
     """
     try:
         _ = polyclonal_obj.fit(**kwargs)
-    except RuntimeError:
+    except PolyclonalFitError:
         return None
 
     return polyclonal_obj
@@ -173,7 +174,7 @@ def _harmonize_epitopes_static(other_poly, ref_poly):
     """
     try:
         other_poly.harmonize_epitopes_with(ref_poly)
-    except ValueError:
+    except PolyclonalHarmonizeError:
         return None
 
     return other_poly


### PR DESCRIPTION
@zorian15, I am making the following changes given how you structure you code. I made custom error classes for the fitting and harmonization errors in `polyclonal`, and then catch those specific classes in `polyclonal_collection`. That way we are only catching the errors we are specifically raising elsewhere, not general errors. Does this look good to you? If so, merge this pull request into `15-bootstrap` and then I can merge that into `main`. 