### PR TITLE
fix plots in concentration_set

### DIFF
--- a/notebooks/concentration_set.ipynb
+++ b/notebooks/concentration_set.ipynb
@@ -457,7 +457,8 @@
     "        [\n",
     "            all_corrs,\n",
     "            corr.assign(\n",
-    "                icxx_set=[' '.join([f\"IC{wt_data_icxx[c]}\" for c in s])] * len(corr.index)\n",
+    "                icxx_set=[\" \".join([f\"IC{wt_data_icxx[c]}\" for c in s])]\n",
+    "                * len(corr.index)\n",
     "            ),\n",
     "        ]\n",
     "    )"
@@ -809,7 +810,8 @@
     "        [\n",
     "            all_corrs,\n",
     "            corr.assign(\n",
-    "                icxx_set=[', '.join([f\"IC{wt_data_icxx[c]}\" for c in s])] * len(corr.index)\n",
+    "                icxx_set=[\", \".join([f\"IC{wt_data_icxx[c]}\" for c in s])]\n",
+    "                * len(corr.index)\n",
     "            ),\n",
     "        ]\n",
     "    ).reset_index(drop=True)"
@@ -899,8 +901,11 @@
     "    tooltip=[\"icxx_set\", alt.Tooltip(\"correlation (R^2)\", format=\".3f\")],\n",
     "    color=alt.Color(\"epitope\", legend=None),\n",
     "    row=\"epitope:N\",\n",
-    ").properties(width=375, height=200, title=\"inferred vs. true mutation escape values\"\n",
-    ").configure_axis(labelLimit=300)"
+    ").properties(\n",
+    "    width=375, height=200, title=\"inferred vs. true mutation escape values\"\n",
+    ").configure_axis(\n",
+    "    labelLimit=300\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
@jbloom Thanks for catching this. I think it's an obscure bug in altair `4.2` where any facet after the first is being messed up. I think it's also related to line breaking, since I tried the solutions described [here](https://github.com/altair-viz/altair/issues/2376) with no luck. I also reproduced the error in this simple example here:
<img width="1058" alt="Screen Shot 2022-03-13 at 6 18 32 PM" src="https://user-images.githubusercontent.com/36126324/158094954-40865903-a469-4605-95e4-b22af884a57a.png">

 I got the plots to work by **not** line breaking the axes labels. It doesn't look as pretty, but I think it'll work for now. Let me know what you think!