### PR TITLE
fix bug in parameter check in `Polyclonal`

### DIFF
--- a/polyclonal/polyclonal.py
+++ b/polyclonal/polyclonal.py
@@ -720,7 +720,7 @@ class Polyclonal:
                 raise ValueError("duplicate epitopes in `activity_wt_df`")
 
         elif (activity_wt_df is None) and (mut_escape_df is None):
-            if not isinstance(n_epitopes, int) and n_epitopes > 0:
+            if not (isinstance(n_epitopes, int) and n_epitopes > 0):
                 raise ValueError(
                     "`n_epitopes` must be int > 1 if no " "`activity_wt_df`"
                 )


### PR DESCRIPTION
Was not previously properly checking that `n_epitopes` is `int` > 0