### PR TITLE
add installation instructions from GitHub

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,8 +3,11 @@ Installation
 
 ``polyclonal`` requires Python 3.8 or higher.
 
-The easiest way to install ``polyclonal`` is from `PyPI <https://pypi.org/>`_ using `pip <https://pip.pypa.io>`_ with::
+Unfortunately ``polyclonal`` cannot currently be installed from `PyPI <https://pypi.org/>`_.
+The reason is that ``polyclonal`` currently uses the `GitHub development version of altair <https://github.com/altair-viz/altair/discussions/2588>`_, which has to be installed from GitHub and `PyPI <https://pypi.org/>`_ does not allow GitHub dependencies.
+Therefore, for now you have to install ``polyclonal`` from GitHub.
+To do this for version 0.1 of ``polyclonal``, you would use this command::
 
-    pip install polyclonal
+    pip install git+https://github.com/jbloomlab/polyclonal/@0.1#egg=polyclonal
 
 The source code for ``polyclonal`` is available on GitHub at https://github.com/jbloomlab/polyclonal.


### PR DESCRIPTION
Right now we can't actually install from `PyPI` as it uses a non-PyPI version (the 5.* development version) of `altair`.

So I've updated the installation instructions to say how to install from GitHub.

@timcyu @matsen @zorian15, can one of you review and merge this? 