### PR TITLE
generalize `mut_escape_heatmap`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+0.2
+---------------------------
+- Add some options that generalize ``mut_escape_heatmap``, specifically:
+  * added ``epitope_label_suffix`` parameter
+  * added ``diverging_colors`` parameter
+  * changed ``percent_max_cutoff`` slider to work on real rather than absolute values and with non-zero minimum values.
+
 0.1
 ---------------------------
 Initial release

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -27,7 +27,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "0.1"
+__version__ = "0.2"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -457,6 +457,7 @@ def mut_escape_heatmap(
     cell_size=12,
     zoom_bar_width=500,
     init_min_times_seen=1,
+    epitope_label_suffix=" epitope",
 ):
     r"""Heatmaps of the mutation escape values, :math:`\beta_{m,e}`.
 
@@ -465,7 +466,7 @@ def mut_escape_heatmap(
     mut_escape_df : pandas.DataFrame
         Mutation-level escape in format of
         :attr:`polyclonal.polyclonal.Polyclonal.mut_escape_df`.
-    alphabet : array-like or None
+    alphabet : array-like
         Alphabet letters (e.g., amino acids) in order to plot them.
     epitope_colors : dict
         Maps each epitope name to its color.
@@ -496,6 +497,8 @@ def mut_escape_heatmap(
         Initial cutoff for minimum times a mutation must be seen slider. Slider
         only shown if 'times_seen' in `addtl_tooltip_stats`. Also used for calculating
         the percent max cutoff values.
+    epitope_label_suffix : str
+        Suffix epitope labels with this.
 
     Returns
     -------
@@ -539,12 +542,13 @@ def mut_escape_heatmap(
                 columns="epitope",
                 aggfunc=lambda x: " ".join(x),
             )
-            .rename(columns={e: f"{e} epitope" for e in epitopes})
+            .rename(columns={e: f"{e}{epitope_label_suffix}" for e in epitopes})
         )
-        escape_tooltips = [f"{e} epitope" for e in epitopes]
+        escape_tooltips = [f"{e}{epitope_label_suffix}" for e in epitopes]
     else:
         escape_tooltips = [
-            alt.Tooltip(e, format=".2f", title=f"{e} epitope") for e in epitopes
+            alt.Tooltip(e, format=".2f", title=f"{e}{epitope_label_suffix}")
+            for e in epitopes
         ]
 
     # add mutation labels and wildtypes
@@ -698,7 +702,7 @@ def mut_escape_heatmap(
                 epitope,
                 type="quantitative",
                 scale=alt.Scale(
-                    range=color_gradient_hex("white", epitope_colors[epitope], 10),
+                    range=color_gradient_hex("white", epitope_colors[epitope], 20),
                     type="linear",
                     domain=(escape_min, escape_max),
                     clamp=True,
@@ -726,7 +730,7 @@ def mut_escape_heatmap(
             )
             .properties(
                 title=alt.TitleParams(
-                    f"{epitope} epitope", color=epitope_colors[epitope]
+                    f"{epitope}{epitope_label_suffix}", color=epitope_colors[epitope]
                 ),
                 width={"step": cell_size},
                 height={"step": cell_size},

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -458,6 +458,7 @@ def mut_escape_heatmap(
     zoom_bar_width=500,
     init_min_times_seen=1,
     epitope_label_suffix=" epitope",
+    diverging_colors=False,
 ):
     r"""Heatmaps of the mutation escape values, :math:`\beta_{m,e}`.
 
@@ -498,7 +499,11 @@ def mut_escape_heatmap(
         only shown if 'times_seen' in `addtl_tooltip_stats`. Also used for calculating
         the percent max cutoff values.
     epitope_label_suffix : str
-        Suffix epitope labels with this.
+        Suffix epitope labels with this.q
+    diverging_colors : bool
+        If `False`, colors in ``epitope_colors`` are assumed to be the upper color for
+        white-to-<color> scale. If `True`, they are instead diverging color schemes with
+        0 as white. Valid diverging schemes: https://vega.github.io/vega/docs/schemes/
 
     Returns
     -------
@@ -706,11 +711,16 @@ def mut_escape_heatmap(
             color=alt.Color(
                 epitope,
                 type="quantitative",
-                scale=alt.Scale(
-                    range=color_gradient_hex("white", epitope_colors[epitope], 20),
-                    type="linear",
-                    domain=(escape_min, escape_max),
-                    clamp=True,
+                # diverging color scales: https://stackoverflow.com/a/70296527
+                scale=(
+                    alt.Scale(domainMid=0, scheme=epitope_colors[epitope])
+                    if diverging_colors else
+                    alt.Scale(
+                        range=color_gradient_hex("white", epitope_colors[epitope], 20),
+                        type="linear",
+                        domain=(escape_min, escape_max),
+                        clamp=True,
+                    )
                 ),
                 legend=alt.Legend(
                     orient="left",
@@ -735,7 +745,8 @@ def mut_escape_heatmap(
             )
             .properties(
                 title=alt.TitleParams(
-                    f"{epitope}{epitope_label_suffix}", color=epitope_colors[epitope]
+                    f"{epitope}{epitope_label_suffix}",
+                    color="black" if diverging_colors else epitope_colors[epitope],
                 ),
                 width={"step": cell_size},
                 height={"step": cell_size},

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -664,9 +664,9 @@ def mut_escape_heatmap(
         .groupby("site", as_index=False)
         .aggregate(_site_max=pd.NamedAgg("_epitope_max", "max"))
         .assign(
-            percent_max=lambda x: (
-                100 * (x["_site_max"] - _min) / (_max - _min)
-            ).clip(lower=0)
+            percent_max=lambda x: (100 * (x["_site_max"] - _min) / (_max - _min)).clip(
+                lower=0
+            )
         )
         .drop(columns="_site_max")
     )
@@ -714,8 +714,8 @@ def mut_escape_heatmap(
                 # diverging color scales: https://stackoverflow.com/a/70296527
                 scale=(
                     alt.Scale(domainMid=0, scheme=epitope_colors[epitope])
-                    if diverging_colors else
-                    alt.Scale(
+                    if diverging_colors
+                    else alt.Scale(
                         range=color_gradient_hex("white", epitope_colors[epitope], 20),
                         type="linear",
                         domain=(escape_min, escape_max),


### PR DESCRIPTION
Add some options that generalize `mut_escape_heatmap` for more plotting uses. This enables it to be used for instance to plot functional scores as well with all the nice interactivity. This isn't really a specific targeted use of the `polyclonal` package, but makes the API more broadly useful.

Specifically:
  * added `epitope_label_suffix` parameter
  * added `diverging_colors` parameter
  * changed `percent_max_cutoff` slider to work on real rather than absolute values and with non-zero minimum values.

This increments version to 0.2.