### PR TITLE
`harmonize_epitopes_with` -> `epitope_harmonized_model` and add `tidy_to_corr`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 ---------------------------
 - Renamed the bootstrapping models from ``PolyclonalCollection`` to ``PolyclonalBootstrap`` and made ``PolyclonalCollection`` a general-purpose class for collection of ``Polyclonal`` objects. This makes the idea of model collections more general, and better aligns the class names with what they actually do. This is a **backward-incompatible change**.
 - Remove the old ``Polyclonal.harmonize_epitopes_with`` method that modified ``Polyclonal`` models in place, and replaced with the new ``Polyclonal.epitope_harmonized_model`` that returns a copy of the original model with the epitopes harmonized and also provides guarantees about consistent epitope order, etc. This is a **backward-incompatible change**.
+- Added ``utils.tidy_to_corr`` function.
 - Added ``polyclonal_collection.fit_models`` to fit multiple models using multiprocessing.
 - Added ``RBD_average.ipynb`` notebook.
 - Fix bug in setting ``epitope_colors`` as dict in ``Polyclonal``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
 1.0
 ---------------------------
-- **Backward incompatible change:** renamed the bootstrapping models from ``PolyclonalCollection`` to ``PolyclonalBootstrap`` and made ``PolyclonalCollection`` a general-purpose class for collection of ``Polyclonal`` objects. This makes the idea of model collections more general, and better aligns the class names with what they actually do.
+- Renamed the bootstrapping models from ``PolyclonalCollection`` to ``PolyclonalBootstrap`` and made ``PolyclonalCollection`` a general-purpose class for collection of ``Polyclonal`` objects. This makes the idea of model collections more general, and better aligns the class names with what they actually do. This is a **backward-incompatible change**.
+- Remove the old ``Polyclonal.harmonize_epitopes_with`` method that modified ``Polyclonal`` models in place, and replaced with the new ``Polyclonal.epitope_harmonized_model`` that returns a copy of the original model with the epitopes harmonized and also provides guarantees about consistent epitope order, etc. This is a **backward-incompatible change**.
 - Added ``polyclonal_collection.fit_models`` to fit multiple models using multiprocessing.
 - Added ``RBD_average.ipynb`` notebook.
 - Fix bug in setting ``epitope_colors`` as dict in ``Polyclonal``.

--- a/polyclonal/utils.py
+++ b/polyclonal/utils.py
@@ -10,6 +10,8 @@ Miscellaneous utility functions.
 
 import re
 
+import pandas as pd  # noqa: F401
+
 import polyclonal
 
 
@@ -172,6 +174,149 @@ def shift_mut_site(mut_str, shift):
         new_site = int(m.group("site")) + shift
         new_mut_str.append(f"{m.group('wt')}{new_site}{m.group('mut')}")
     return " ".join(new_mut_str)
+
+
+def tidy_to_corr(
+    df,
+    sample_col,
+    label_col,
+    value_col,
+    *,
+    group_cols=None,
+    return_type="tidy_pairs",
+    method="pearson",
+):
+    """Pairwise correlations between samples in tidy data frame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Tidy data frame.
+    sample_col : str
+        Column in `df` with name of sample.
+    label_col : str
+        Column in `df` with labels for variable to correlate.
+    value_col : str
+        Column in `df` with values to correlate.
+    group_cols : None, str, or list
+        Additional columns used to group results.
+    return_type : {'tidy_pairs', 'matrix'}
+        Return results as tidy dataframe of pairwise correlations
+        or correlation matrix.
+    method : str
+        A correlation method passable to `pandas.DataFrame.corr`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Holds pairwise correlations in format specified by `return_type`.
+        Correlations only calculated among values with shared label
+        among samples.
+
+    Example
+    -------
+    Define data frame with data to correlate:
+
+    >>> df = pd.DataFrame({
+    ...        'sample': ['a', 'a', 'a', 'b', 'b', 'b', 'b', 'c', 'c', 'c'],
+    ...        'barcode': ['A', 'C', 'G', 'G', 'A', 'C', 'T', 'G', 'C', 'A'],
+    ...        'score': [1, 2, 3, 3, 1.5, 2, 4, 1, 2, 3],
+    ...        'group': ['x', 'x', 'x', 'x', 'x', 'x', 'x', 'y', 'y', 'y'],
+    ...        })
+
+    Pairwise correlations between all samples ignoring group:
+
+    >>> tidy_to_corr(df, sample_col='sample', label_col='barcode',
+    ...              value_col='score')
+      sample_1 sample_2  correlation
+    0        a        a     1.000000
+    1        b        a     0.981981
+    2        c        a    -1.000000
+    3        a        b     0.981981
+    4        b        b     1.000000
+    5        c        b    -0.981981
+    6        a        c    -1.000000
+    7        b        c    -0.981981
+    8        c        c     1.000000
+
+    The same but as a matrix rather than in tidy format:
+
+    >>> tidy_to_corr(df, sample_col='sample', label_col='barcode',
+    ...              value_col='score', return_type='matrix')
+      sample         a         b         c
+    0      a  1.000000  0.981981 -1.000000
+    1      b  0.981981  1.000000 -0.981981
+    2      c -1.000000 -0.981981  1.000000
+
+    Now group before computing correlations:
+
+    >>> tidy_to_corr(df, sample_col='sample', label_col='barcode',
+    ...              value_col='score', group_cols='group')
+      group sample_1 sample_2  correlation
+    0     x        a        a     1.000000
+    1     x        b        a     0.981981
+    2     x        a        b     0.981981
+    3     x        b        b     1.000000
+    4     y        c        c     1.000000
+    >>> tidy_to_corr(df, sample_col='sample', label_col='barcode',
+    ...              value_col='score', group_cols='group',
+    ...              return_type='matrix')
+      group sample         a         b    c
+    0     x      a  1.000000  0.981981  NaN
+    1     x      b  0.981981  1.000000  NaN
+    2     y      c       NaN       NaN  1.0
+
+    """
+    if isinstance(group_cols, str):
+        group_cols = [group_cols]
+    elif group_cols is None:
+        group_cols = []
+    cols = [sample_col, value_col, label_col] + group_cols
+    if set(cols) > set(df.columns):
+        raise ValueError(f"`df` missing some of these columns: {cols}")
+    if len(set(cols)) != len(cols):
+        raise ValueError(f"duplicate column names: {cols}")
+    if "correlation" in cols:
+        raise ValueError("cannot have column named `correlation`")
+    if sample_col + "_2" in group_cols:
+        raise ValueError(f"cannot have column named `{sample_col}_2`")
+
+    for _, g in df.groupby([sample_col] + group_cols):
+        if len(g[label_col]) != g[label_col].nunique():
+            raise ValueError(
+                f"Entries in `df` column {label_col} not unique "
+                "after grouping by: " + ", ".join(c for c in [sample_col] + group_cols)
+            )
+
+    df = df.pivot_table(
+        values=value_col,
+        columns=sample_col,
+        index=[label_col] + group_cols,
+    ).reset_index()
+
+    if group_cols:
+        df = df.groupby(group_cols)
+
+    corr = df.corr(method=method).dropna(how="all", axis="index").reset_index()
+
+    corr.columns.name = None  # remove name of columns index
+
+    if return_type == "tidy_pairs":
+        corr = (
+            corr.melt(
+                id_vars=group_cols + [sample_col],
+                var_name=sample_col + "_2",
+                value_name="correlation",
+            )
+            .rename(columns={sample_col: sample_col + "_1"})
+            .dropna()
+            .reset_index(drop=True)
+        )
+
+    elif return_type != "matrix":
+        raise ValueError(f"invalid `return_type` of {return_type}")
+
+    return corr
 
 
 if __name__ == "__main__":

--- a/tests/test_epitope_harmony.ipynb
+++ b/tests/test_epitope_harmony.ipynb
@@ -22,11 +22,11 @@
    "id": "5935c6e6-a5ae-4d73-8f80-03c7d36775f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:34.703263Z",
-     "iopub.status.busy": "2022-07-17T14:05:34.702757Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.115386Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.114634Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:34.703187Z"
+     "iopub.execute_input": "2022-07-17T20:47:20.169916Z",
+     "iopub.status.busy": "2022-07-17T20:47:20.169668Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.542438Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.541796Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:20.169833Z"
     },
     "tags": []
    },
@@ -101,12 +101,13 @@
    "id": "0667e765-d0d7-40fc-b21b-c2da5fedec23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.118810Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.118675Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.210221Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.209746Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.118792Z"
-    }
+     "iopub.execute_input": "2022-07-17T20:47:21.545826Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.545691Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.589163Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.588736Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.545806Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -187,12 +188,13 @@
    "id": "dc7821f2-8572-4e0f-ab8a-14db2d72fbe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.214384Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.214145Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.291413Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.290843Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.214365Z"
-    }
+     "iopub.execute_input": "2022-07-17T20:47:21.593141Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.592901Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.628337Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.627870Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.593120Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -273,12 +275,13 @@
    "id": "7cb53b02-4c88-4087-9ff6-cab8b174bf66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.294243Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.294106Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.372072Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.371403Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.294226Z"
-    }
+     "iopub.execute_input": "2022-07-17T20:47:21.630673Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.630499Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.665758Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.665293Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.630655Z"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -310,27 +313,27 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>2</td>\n",
        "      <td>1</td>\n",
-       "      <td>1.000000</td>\n",
+       "      <td>1</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>-0.860309</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>-0.860309</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
        "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1</td>\n",
+       "      <td>1.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -338,10 +341,10 @@
       ],
       "text/plain": [
        "  ref_epitope self_epitope  correlation\n",
-       "0           2            1     1.000000\n",
-       "1           2            2    -0.860309\n",
-       "2           1            1    -0.860309\n",
-       "3           1            2     1.000000"
+       "0           1            1    -0.860309\n",
+       "1           1            2     1.000000\n",
+       "2           2            1     1.000000\n",
+       "3           2            2    -0.860309"
       ]
      },
      "execution_count": 4,
@@ -368,11 +371,11 @@
    "id": "b1f728e8-4fa1-4d2b-8c0d-0cd0adaacab3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.374893Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.374761Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.483098Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.482274Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.374875Z"
+     "iopub.execute_input": "2022-07-17T20:47:21.668300Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.668009Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.741971Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.740961Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.668282Z"
     },
     "tags": []
    },
@@ -407,11 +410,11 @@
    "id": "b442f4eb-64db-45c4-b3f7-f82a5e32b043",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.486295Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.486047Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.594211Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.593571Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.486275Z"
+     "iopub.execute_input": "2022-07-17T20:47:21.745158Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.745016Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.817197Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.816223Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.745139Z"
     },
     "tags": []
    },
@@ -446,11 +449,11 @@
    "id": "098ad681-2a96-4e1f-ace0-083fc9b63410",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-07-17T14:05:36.596889Z",
-     "iopub.status.busy": "2022-07-17T14:05:36.596714Z",
-     "iopub.status.idle": "2022-07-17T14:05:36.710268Z",
-     "shell.execute_reply": "2022-07-17T14:05:36.709547Z",
-     "shell.execute_reply.started": "2022-07-17T14:05:36.596868Z"
+     "iopub.execute_input": "2022-07-17T20:47:21.820812Z",
+     "iopub.status.busy": "2022-07-17T20:47:21.820681Z",
+     "iopub.status.idle": "2022-07-17T20:47:21.883917Z",
+     "shell.execute_reply": "2022-07-17T20:47:21.883339Z",
+     "shell.execute_reply.started": "2022-07-17T20:47:21.820793Z"
     },
     "tags": []
    },

--- a/tests/test_epitope_harmony.ipynb
+++ b/tests/test_epitope_harmony.ipynb
@@ -5,7 +5,7 @@
    "id": "de4e3acd-bf50-4bbf-a70f-cbac40ff7749",
    "metadata": {},
    "source": [
-    "# Test epitope harmonizing"
+    "# Test epitope correlations and harmonizing"
    ]
   },
   {
@@ -13,7 +13,7 @@
    "id": "ab3f766b-ea28-42e2-ac00-8d725f367b0c",
    "metadata": {},
    "source": [
-    "## Setup"
+    "First we create three models: two are identical, one has epitopes flipped relative to the others but listed in the same order, and the other has epitopes flipped and listed in the opposite order:"
    ]
   },
   {
@@ -22,28 +22,24 @@
    "id": "5935c6e6-a5ae-4d73-8f80-03c7d36775f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:55.528641Z",
-     "iopub.status.busy": "2022-04-10T19:51:55.528171Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.062925Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.062272Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:55.528566Z"
-    }
+     "iopub.execute_input": "2022-07-17T14:05:34.703263Z",
+     "iopub.status.busy": "2022-07-17T14:05:34.702757Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.115386Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.114634Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:34.703187Z"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
-    "import numpy\n",
-    "\n",
-    "import random\n",
+    "import copy\n",
     "\n",
     "import pandas as pd\n",
     "\n",
     "from polyclonal import Polyclonal\n",
     "\n",
-    "import polyclonal.utils as utils\n",
     "\n",
-    "import unittest\n",
-    "\n",
-    "activity_wt_df = pd.DataFrame({\"epitope\": [\"1\", \"2\"], \"activity\": [2.0, 1.0]})\n",
+    "activity_wt_df = pd.DataFrame({\"epitope\": [1, 2], \"activity\": [2.0, 1.0]})\n",
     "\n",
     "mut_escape_df = pd.DataFrame(\n",
     "    {\n",
@@ -59,114 +55,57 @@
     "            \"A4Q\",\n",
     "            \"A4Q\",\n",
     "        ],\n",
-    "        \"epitope\": [\"1\", \"2\", \"1\", \"2\", \"1\", \"2\", \"1\", \"2\", \"1\", \"2\"],\n",
+    "        \"epitope\": [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],\n",
     "        \"escape\": [2.0, 0.0, 3.0, 0.0, 0.0, 2.5, 0.0, 1.5, 0.0, 3.5],\n",
     "    }\n",
     ")\n",
     "\n",
-    "polyclonal_sim = Polyclonal(activity_wt_df=activity_wt_df, mut_escape_df=mut_escape_df)\n",
+    "model = Polyclonal(mut_escape_df=mut_escape_df, activity_wt_df=activity_wt_df)\n",
     "\n",
-    "variants_df = pd.DataFrame.from_records(\n",
-    "    [\n",
-    "        (\"AA\", \"\"),\n",
-    "        (\"AC\", \"M1C\"),\n",
-    "        (\"AG\", \"G2A\"),\n",
-    "        (\"AT\", \"A4K\"),\n",
-    "        (\"TA\", \"A4L\"),\n",
-    "        (\"GA\", \"A4Q\"),\n",
-    "        (\"CA\", \"M1C G2A\"),\n",
-    "        (\"CG\", \"M1C A4K\"),\n",
-    "        (\"TT\", \"M1C A4L\"),\n",
-    "        (\"GT\", \"M1C A4Q\"),\n",
-    "        (\"CC\", \"G2A A4K\"),\n",
-    "        (\"TC\", \"G2A A4L\"),\n",
-    "        (\"GG\", \"G2A A4Q\"),\n",
-    "        (\"CT\", \"M1C G2A A4K\"),\n",
-    "        (\"TG\", \"M1C G2A A4L\"),\n",
-    "        (\"GA\", \"M1C G2A A4Q\"),\n",
-    "    ],\n",
-    "    columns=[\"barcode\", \"aa_substitutions\"],\n",
+    "model_copy = copy.deepcopy(model)\n",
+    "\n",
+    "model_flipped = Polyclonal(\n",
+    "    mut_escape_df=(\n",
+    "        mut_escape_df.assign(\n",
+    "            epitope=lambda x: x[\"epitope\"].map({1: 2, 2: 1})\n",
+    "        ).sort_values(\"epitope\")\n",
+    "    ),\n",
+    "    activity_wt_df=(\n",
+    "        activity_wt_df.assign(\n",
+    "            epitope=lambda x: x[\"epitope\"].map({1: 2, 2: 1})\n",
+    "        ).sort_values(\"epitope\")\n",
+    "    ),\n",
     ")\n",
     "\n",
-    "escape_probs = polyclonal_sim.prob_escape(\n",
-    "    variants_df=variants_df, concentrations=[1.0, 2.0, 4.0]\n",
-    ")\n",
-    "\n",
-    "data_to_fit = escape_probs.rename(columns={\"predicted_prob_escape\": \"prob_escape\"})"
+    "model_flipped_diff_order = Polyclonal(\n",
+    "    mut_escape_df=(\n",
+    "        mut_escape_df.assign(epitope=lambda x: x[\"epitope\"].map({1: 2, 2: 1}))\n",
+    "    ),\n",
+    "    activity_wt_df=(\n",
+    "        activity_wt_df.assign(epitope=lambda x: x[\"epitope\"].map({1: 2, 2: 1}))\n",
+    "    ),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a72539c-902d-4aaa-a052-52416a7bfd81",
+   "metadata": {},
+   "source": [
+    "Now look at correlations among epitopes:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "e17d0c08-27d2-4cc9-bbd4-02abcd14d7c2",
+   "id": "0667e765-d0d7-40fc-b21b-c2da5fedec23",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.066006Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.065817Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.099958Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.099168Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.065984Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "n_eps = 2\n",
-    "poly_one = Polyclonal(\n",
-    "    data_to_fit=data_to_fit, n_epitopes=n_eps, activity_wt_df=None, site_escape_df=None\n",
-    ")\n",
-    "poly_two = Polyclonal(\n",
-    "    data_to_fit=data_to_fit, n_epitopes=n_eps, activity_wt_df=None, site_escape_df=None\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "f6342877-1097-44e2-b55a-efdde6687c52",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.106213Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.105849Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.274161Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.273331Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.106192Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "random.seed(1)\n",
-    "_ = poly_one.fit(fit_site_level_first=False, reg_activity_weight=0)\n",
-    "_ = poly_two.fit(fit_site_level_first=False, reg_activity_weight=0)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "732f808e-be0a-4434-aa8e-f3b54896c2a3",
-   "metadata": {},
-   "source": [
-    "## Tests"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9092e1f8-a762-4d54-9ef4-45fddea18b4c",
-   "metadata": {},
-   "source": [
-    "### Epitope correlation\n",
-    "The following tests assess if the helper methods for epitope harmonizing all work when we have two identical models (1s in correlation matrix should be on diagonal):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "bcee9d95-a18f-4885-92bf-f14b569a72ab",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.277525Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.277323Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.391131Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.390613Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.277505Z"
+     "iopub.execute_input": "2022-07-17T14:05:36.118810Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.118675Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.210221Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.209746Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.118792Z"
     }
    },
    "outputs": [
@@ -207,13 +146,13 @@
        "      <th>1</th>\n",
        "      <td>1</td>\n",
        "      <td>2</td>\n",
-       "      <td>-0.868396</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>2</td>\n",
        "      <td>1</td>\n",
-       "      <td>-0.868396</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -228,429 +167,31 @@
       "text/plain": [
        "  ref_epitope self_epitope  correlation\n",
        "0           1            1     1.000000\n",
-       "1           1            2    -0.868396\n",
-       "2           2            1    -0.868396\n",
+       "1           1            2    -0.860309\n",
+       "2           2            1    -0.860309\n",
        "3           2            2     1.000000"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "corr_df = poly_two.mut_escape_corr(poly_one)\n",
-    "assert len(corr_df) == n_eps**2\n",
-    "assert corr_df.correlation.between(-1, 1).all()\n",
-    "corr_df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1cea925e-e61c-46cd-b4bf-6dd743e75f88",
-   "metadata": {},
-   "source": [
-    "#### Scenario: Flipped `mut_escape_df`"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9d9191a4-2e73-44f6-880c-b01f10c024d7",
-   "metadata": {},
-   "source": [
-    "Now, we will create an example where we train two models that learn the same parameters but flip the epitopes (i.e., I'm just going to flip the values in `mut_escape_df` from one model, and re-create polyclonal objects:"
+    "model.mut_escape_corr(model_copy)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "0207ee00-4d5a-4508-84d3-adff482e65b3",
+   "execution_count": 3,
+   "id": "dc7821f2-8572-4e0f-ab8a-14db2d72fbe7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.393849Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.393660Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.424205Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.423602Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.393830Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# Create a test example where two models \"flipped\" the epitopes\n",
-    "one_df = poly_one.mut_escape_df\n",
-    "two_df = poly_two.mut_escape_df\n",
-    "one_wt_df = poly_one.activity_wt_df\n",
-    "two_wt_df = pd.DataFrame(\n",
-    "    {\"epitope\": one_wt_df.epitope.values, \"activity\": one_wt_df.activity[::-1]}\n",
-    ")\n",
-    "\n",
-    "# Create a \"flipped\" version of the `activity_wt_df`\n",
-    "two_df[\"escape\"] = one_df.escape[5:10].tolist() + one_df.escape[0:5].tolist()\n",
-    "\n",
-    "# Create polyclonal objects (can't seem to edit `mut_escape_df` bc it's a property)\n",
-    "original_poly = Polyclonal(\n",
-    "    mut_escape_df=one_df, activity_wt_df=one_wt_df, data_to_fit=None\n",
-    ")\n",
-    "flipped_poly = Polyclonal(\n",
-    "    mut_escape_df=two_df, activity_wt_df=two_wt_df, data_to_fit=None\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e7411789-7a9e-483a-8f18-68c2f5686c45",
-   "metadata": {},
-   "source": [
-    "##### Sanity checks\n",
-    "Here, we just want to make sure the `mut_escape_df` properties for each `Polyclonal` object are flipped. \n",
-    "This should result in the escape values for a given mutation (i.e. M1C), in epitopes 1 and of the `orignal_poly` object to be flipped in the `flipped_poly` object, and so on.\n",
-    "\n",
-    "This should manifest in the `_params` data field as binary swaps across the arrays (i.e. [1, 2, 3, 4] --> [2,1,4,3]) after the first two epitope params (because params are on a mutation-epitope ordering)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "id": "219b9d4a-becd-4d0f-b21c-64860a440363",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.426800Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.426671Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.440651Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.440125Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.426782Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>epitope</th>\n",
-       "      <th>site</th>\n",
-       "      <th>wildtype</th>\n",
-       "      <th>mutant</th>\n",
-       "      <th>mutation</th>\n",
-       "      <th>escape</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>0.150825</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>0.048918</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>2.328576</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>1.477875</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>3.005967</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>2.017121</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>3.170534</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>0.019587</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>-0.043629</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>0.084637</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  epitope  site wildtype mutant mutation    escape\n",
-       "0       1     1        M      C      M1C  0.150825\n",
-       "1       1     2        G      A      G2A  0.048918\n",
-       "2       1     4        A      K      A4K  2.328576\n",
-       "3       1     4        A      L      A4L  1.477875\n",
-       "4       1     4        A      Q      A4Q  3.005967\n",
-       "5       2     1        M      C      M1C  2.017121\n",
-       "6       2     2        G      A      G2A  3.170534\n",
-       "7       2     4        A      K      A4K  0.019587\n",
-       "8       2     4        A      L      A4L -0.043629\n",
-       "9       2     4        A      Q      A4Q  0.084637"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "original_poly.mut_escape_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "1ca2b2df-b5d4-46ac-adee-0f1fd8d0ecd9",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.443295Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.443058Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.456484Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.455998Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.443274Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>epitope</th>\n",
-       "      <th>site</th>\n",
-       "      <th>wildtype</th>\n",
-       "      <th>mutant</th>\n",
-       "      <th>mutation</th>\n",
-       "      <th>escape</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>2.017121</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>3.170534</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>0.019587</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>-0.043629</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>0.084637</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>0.150825</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>0.048918</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>2.328576</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>1.477875</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>3.005967</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  epitope  site wildtype mutant mutation    escape\n",
-       "0       1     1        M      C      M1C  2.017121\n",
-       "1       1     2        G      A      G2A  3.170534\n",
-       "2       1     4        A      K      A4K  0.019587\n",
-       "3       1     4        A      L      A4L -0.043629\n",
-       "4       1     4        A      Q      A4Q  0.084637\n",
-       "5       2     1        M      C      M1C  0.150825\n",
-       "6       2     2        G      A      G2A  0.048918\n",
-       "7       2     4        A      K      A4K  2.328576\n",
-       "8       2     4        A      L      A4L  1.477875\n",
-       "9       2     4        A      Q      A4Q  3.005967"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "flipped_poly.mut_escape_df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d2de6cb9-fdf1-42f3-9977-17f7eb1945d0",
-   "metadata": {},
-   "source": [
-    "#### Scenario: Helper method input violations\n",
-    "Another set of tests on the helper methods, this time, 1s should be on the \"off-diagonal\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "816a369a-22e9-4194-8599-fb7f6dbefafe",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.459062Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.458878Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.544468Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.543952Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.459044Z"
+     "iopub.execute_input": "2022-07-17T14:05:36.214384Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.214145Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.291413Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.290843Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.214365Z"
     }
    },
    "outputs": [
@@ -685,7 +226,7 @@
        "      <th>0</th>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>-0.868396</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -703,7 +244,7 @@
        "      <th>3</th>\n",
        "      <td>2</td>\n",
        "      <td>2</td>\n",
-       "      <td>-0.868396</td>\n",
+       "      <td>-0.860309</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -711,47 +252,32 @@
       ],
       "text/plain": [
        "  ref_epitope self_epitope  correlation\n",
-       "0           1            1    -0.868396\n",
+       "0           1            1    -0.860309\n",
        "1           1            2     1.000000\n",
        "2           2            1     1.000000\n",
-       "3           2            2    -0.868396"
+       "3           2            2    -0.860309"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "corr_df2 = flipped_poly.mut_escape_corr(original_poly)\n",
-    "assert len(corr_df2) == n_eps**2\n",
-    "assert corr_df2.correlation.between(-1, 1).all()\n",
-    "corr_df2"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ba79ca4f-779b-4fd3-aa01-804243830d69",
-   "metadata": {},
-   "source": [
-    "### Epitope harmonization\n",
-    "\n",
-    "Now we harmonize the flipped object with the original one -- since these are the exact same dataframes but with flipped epitopes, after harmonization, `flipped_poly.mut_escape_df` should be equal to `original_poly.mut_escape_df`.\n",
-    "\n",
-    "We should also have equal `activity_wt_df` and `_params` propertoes after harmonization as well."
+    "model.mut_escape_corr(model_flipped)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "3a07b264-6f82-4280-8bcf-233aa78fe291",
+   "execution_count": 4,
+   "id": "7cb53b02-4c88-4087-9ff6-cab8b174bf66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.545534Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.545289Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.558803Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.558312Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.545514Z"
+     "iopub.execute_input": "2022-07-17T14:05:36.294243Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.294106Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.372072Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.371403Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.294226Z"
     }
    },
    "outputs": [
@@ -776,239 +302,175 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
-       "      <th>epitope</th>\n",
-       "      <th>site</th>\n",
-       "      <th>wildtype</th>\n",
-       "      <th>mutant</th>\n",
-       "      <th>mutation</th>\n",
-       "      <th>escape</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>2.017121</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>3.170534</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>0.019587</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>-0.043629</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>1</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>0.084637</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>2</td>\n",
-       "      <td>1</td>\n",
-       "      <td>M</td>\n",
-       "      <td>C</td>\n",
-       "      <td>M1C</td>\n",
-       "      <td>0.150825</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>G</td>\n",
-       "      <td>A</td>\n",
-       "      <td>G2A</td>\n",
-       "      <td>0.048918</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>K</td>\n",
-       "      <td>A4K</td>\n",
-       "      <td>2.328576</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>L</td>\n",
-       "      <td>A4L</td>\n",
-       "      <td>1.477875</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>2</td>\n",
-       "      <td>4</td>\n",
-       "      <td>A</td>\n",
-       "      <td>Q</td>\n",
-       "      <td>A4Q</td>\n",
-       "      <td>3.005967</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  epitope  site wildtype mutant mutation    escape\n",
-       "0       1     1        M      C      M1C  2.017121\n",
-       "1       1     2        G      A      G2A  3.170534\n",
-       "2       1     4        A      K      A4K  0.019587\n",
-       "3       1     4        A      L      A4L -0.043629\n",
-       "4       1     4        A      Q      A4Q  0.084637\n",
-       "5       2     1        M      C      M1C  0.150825\n",
-       "6       2     2        G      A      G2A  0.048918\n",
-       "7       2     4        A      K      A4K  2.328576\n",
-       "8       2     4        A      L      A4L  1.477875\n",
-       "9       2     4        A      Q      A4Q  3.005967"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "flipped_poly.mut_escape_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "id": "f9b42ab2-a604-4621-8a59-6bff620d4f6c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2022-04-10T19:51:57.559818Z",
-     "iopub.status.busy": "2022-04-10T19:51:57.559568Z",
-     "iopub.status.idle": "2022-04-10T19:51:57.689336Z",
-     "shell.execute_reply": "2022-04-10T19:51:57.688668Z",
-     "shell.execute_reply.started": "2022-04-10T19:51:57.559796Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>self_initial_epitope</th>\n",
-       "      <th>self_harmonized_epitope</th>\n",
        "      <th>ref_epitope</th>\n",
+       "      <th>self_epitope</th>\n",
        "      <th>correlation</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>2</td>\n",
        "      <td>1</td>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-0.860309</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
        "      <td>1</td>\n",
        "      <td>1</td>\n",
-       "      <td>1.0</td>\n",
+       "      <td>-0.860309</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.000000</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "  self_initial_epitope self_harmonized_epitope ref_epitope  correlation\n",
-       "0                    1                       2           2          1.0\n",
-       "1                    2                       1           1          1.0"
+       "  ref_epitope self_epitope  correlation\n",
+       "0           2            1     1.000000\n",
+       "1           2            2    -0.860309\n",
+       "2           1            1    -0.860309\n",
+       "3           1            2     1.000000"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "assert not any(\n",
-    "    flipped_poly.mut_escape_df[[\"epitope\", \"mutation\", \"escape\"]]\n",
-    "    .merge(original_poly.mut_escape_df, how=\"outer\", on=[\"epitope\", \"mutation\"])\n",
-    "    .assign(equal=lambda x: x[\"escape_x\"] == x[\"escape_y\"])[\"equal\"]\n",
-    ")\n",
-    "assert not any(\n",
-    "    flipped_poly.activity_wt_df[[\"epitope\", \"activity\"]]\n",
-    "    .merge(original_poly.activity_wt_df, how=\"outer\", on=[\"epitope\"])\n",
-    "    .assign(equal=lambda x: x[\"activity_x\"] == x[\"activity_y\"])[\"equal\"]\n",
-    ")\n",
-    "\n",
-    "map_df = flipped_poly.harmonize_epitopes_with(original_poly)\n",
-    "\n",
-    "assert all(\n",
-    "    flipped_poly.mut_escape_df[[\"epitope\", \"mutation\", \"escape\"]]\n",
-    "    .merge(original_poly.mut_escape_df, how=\"outer\", on=[\"epitope\", \"mutation\"])\n",
-    "    .assign(equal=lambda x: x[\"escape_x\"] == x[\"escape_y\"])[\"equal\"]\n",
-    ")\n",
-    "assert all(\n",
-    "    flipped_poly.activity_wt_df[[\"epitope\", \"activity\"]]\n",
-    "    .merge(original_poly.activity_wt_df, how=\"outer\", on=[\"epitope\"])\n",
-    "    .assign(equal=lambda x: x[\"activity_x\"] == x[\"activity_y\"])[\"equal\"]\n",
-    ")\n",
-    "\n",
-    "map_df"
+    "model.mut_escape_corr(model_flipped_diff_order)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76c084ad-73ad-448a-a2d9-2a882724934f",
+   "metadata": {},
+   "source": [
+    "Now harmonize epitopes.\n",
+    "First, if we harmonize the identical models, nothing should change:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "e9b64ba0-c13a-46a7-bf67-a7f30218e0c0",
-   "metadata": {},
+   "execution_count": 5,
+   "id": "b1f728e8-4fa1-4d2b-8c0d-0cd0adaacab3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-17T14:05:36.374893Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.374761Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.483098Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.482274Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.374875Z"
+    },
+    "tags": []
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "assert model.epitopes == model_copy.epitopes\n",
+    "assert model.epitope_colors == model_copy.epitope_colors\n",
+    "assert model.activity_wt_df.equals(model_copy.activity_wt_df)\n",
+    "assert model.mut_escape_df.equals(model_copy.mut_escape_df)\n",
+    "\n",
+    "model_copy_harmonized, _ = model_copy.epitope_harmonized_model(model)\n",
+    "\n",
+    "assert model.epitopes == model_copy_harmonized.epitopes\n",
+    "assert model.epitope_colors == model_copy_harmonized.epitope_colors\n",
+    "assert model.activity_wt_df.equals(model_copy_harmonized.activity_wt_df)\n",
+    "assert model.mut_escape_df.equals(model_copy_harmonized.mut_escape_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a24857d5-ddba-42ba-9158-97b8a4356fa6",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Now harmonize model with different epitopes in same order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b442f4eb-64db-45c4-b3f7-f82a5e32b043",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-17T14:05:36.486295Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.486047Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.594211Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.593571Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.486275Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert model.epitopes == model_flipped.epitopes\n",
+    "assert model.epitope_colors == model_flipped.epitope_colors\n",
+    "assert not model.activity_wt_df.equals(model_flipped.activity_wt_df)\n",
+    "assert not model.mut_escape_df.equals(model_flipped.mut_escape_df)\n",
+    "\n",
+    "model_flipped_harmonized, _ = model_flipped.epitope_harmonized_model(model)\n",
+    "\n",
+    "assert model.epitopes == model_flipped_harmonized.epitopes\n",
+    "assert model.epitope_colors == model_flipped_harmonized.epitope_colors\n",
+    "assert model.activity_wt_df.equals(model_flipped_harmonized.activity_wt_df)\n",
+    "assert model.mut_escape_df.equals(model_flipped_harmonized.mut_escape_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29ed5f08-1dea-410c-adae-5b1fd42a45e9",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Now harmonize model with different epitopes in same order:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "098ad681-2a96-4e1f-ace0-083fc9b63410",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2022-07-17T14:05:36.596889Z",
+     "iopub.status.busy": "2022-07-17T14:05:36.596714Z",
+     "iopub.status.idle": "2022-07-17T14:05:36.710268Z",
+     "shell.execute_reply": "2022-07-17T14:05:36.709547Z",
+     "shell.execute_reply.started": "2022-07-17T14:05:36.596868Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "assert model.epitopes != model_flipped_diff_order.epitopes\n",
+    "assert model.epitope_colors != model_flipped_diff_order.epitope_colors\n",
+    "assert not model.activity_wt_df.equals(model_flipped_diff_order.activity_wt_df)\n",
+    "assert not model.mut_escape_df.equals(model_flipped_diff_order.mut_escape_df)\n",
+    "\n",
+    "(\n",
+    "    model_flipped_diff_order_harmonized,\n",
+    "    _,\n",
+    ") = model_flipped_diff_order.epitope_harmonized_model(model)\n",
+    "\n",
+    "assert model.epitopes == model_flipped_diff_order_harmonized.epitopes\n",
+    "assert model.epitope_colors == model_flipped_diff_order_harmonized.epitope_colors\n",
+    "assert model.activity_wt_df.equals(model_flipped_diff_order_harmonized.activity_wt_df)\n",
+    "assert model.mut_escape_df.equals(model_flipped_diff_order_harmonized.mut_escape_df)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
The old method for harmonizing epitopes, `Polyclonal.harmonize_epitopes_with`, had several shortcomings. It modified the model in place, and did not guarantee consistent epitope order. It worked with bootstrapping when the models to be harmonized were only created for that purpose, but won't work for things like model averaging as we are working to do to address #95.
    
The new `Polyclonal.epitope_harmonized_model` returns a copy of the original model and guarantees harmonized models in consistent order, and so is suitable for purposes like model averaging. This new method replaces `Polyclonal.harmonize_epitopes_with`, so this is a **backward incompatible** change.

Also added a general function for data frame correlations (`tidy_to_corr), and now use it for the `Polyclonal` epitope harmonization correlations.