### PR TITLE
Add preprint link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,4 +16,6 @@ The source code is `on GitHub <https://github.com/jbloomlab/polyclonal>`_.
 
 See the `polyclonal documentation <https://jbloomlab.github.io/polyclonal>`_ for details on how to install and use ``polyclonal``.
 
+See the `preprint <https://doi.org/10.1101/2022.09.17.508366>`_ for conceptual and mathematical descriptions of the model.
+
 To contribute to this package, read the instructions in `CONTRIBUTING.rst <CONTRIBUTING.rst>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,3 +33,7 @@ Contents
    polyclonal
    package_index
    acknowledgments
+
+Citation
+----------
+ `Yu TC, Thornton ZT, Hannon WW, DeWitt WS, Radford CE, Matsen IV FA, Bloom JD. A biophysical model of viral escape from polyclonal antibodies. bioRxiv. (2022) <https://doi.org/10.1101/2022.09.17.508366>`_


### PR DESCRIPTION
This PR just adds 1) a link to the preprint in the GitHub README and 2) a citation to the preprint in the docs. 