### PR TITLE
`lineplot_and_heatmap` compute heatmap range after applying min specified for sliders

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+2.3
+---
+- ``lineplot_and_heatmap`` computes the limit for the heatmap range **after** applying the minimum filters specified in the filters. This avoids having the range determined by mutations that are never plotted, and so is sort of a bug fix (prior behavior wasn't strictly a bug, but did not give sensible behavior).
+
 2.2
 ---
 - Require at least ``pandas`` 1.5.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,8 +6,8 @@ Installation
 Unfortunately ``polyclonal`` cannot currently be installed from `PyPI <https://pypi.org/>`_.
 The reason is that ``polyclonal`` currently uses the `GitHub development version of altair <https://github.com/altair-viz/altair/discussions/2588>`_, which has to be installed from GitHub and `PyPI <https://pypi.org/>`_ does not allow GitHub dependencies.
 Therefore, for now you have to install ``polyclonal`` from GitHub.
-To do this for version 2.2 of ``polyclonal``, you would use this command::
+To do this for version 2.3 of ``polyclonal``, you would use this command::
 
-    pip install git+https://github.com/jbloomlab/polyclonal/@2.2#egg=polyclonal
+    pip install git+https://github.com/jbloomlab/polyclonal/@2.3#egg=polyclonal
 
 The source code for ``polyclonal`` is available on GitHub at https://github.com/jbloomlab/polyclonal.

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -31,7 +31,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "2.2"
+__version__ = "2.3"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -369,6 +369,8 @@ def lineplot_and_heatmap(
     data_df = data_df[req_cols].reset_index(drop=True)
 
     # filter `data_df` by any minimums in `slider_binding_range_kwargs`
+    if slider_binding_range_kwargs is None:
+        slider_binding_range_kwargs = {}
     for col, col_kwargs in slider_binding_range_kwargs.items():
         if "min" in col_kwargs:
             data_df = data_df[data_df[col] >= col_kwargs["min"]]
@@ -437,8 +439,6 @@ def lineplot_and_heatmap(
 
     # create sliders for max of statistic at site and any additional sliders
     sliders = {}
-    if slider_binding_range_kwargs is None:
-        slider_binding_range_kwargs = {}
     for slider_stat, init_slider_stat in addtl_slider_stats.items():
         binding_range_kwargs = {
             "min": data_df[slider_stat].min(),

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -368,6 +368,11 @@ def lineplot_and_heatmap(
         raise ValueError(f"No columns can start with '_stat' in {data_df.columns=}")
     data_df = data_df[req_cols].reset_index(drop=True)
 
+    # filter `data_df` by any minimums in `slider_binding_range_kwargs`
+    for col, col_kwargs in slider_binding_range_kwargs.items():
+        if "min" in col_kwargs:
+            data_df = data_df[data_df[col] >= col_kwargs["min"]]
+
     categories = data_df[category_col].unique().tolist()
     show_category_label = show_single_category_label or (len(categories) > 1)
 


### PR DESCRIPTION
This avoids having the range determined by mutations that are never plotted, and so is sort of a bug fix (prior behavior wasn't strictly a bug, but did not give sensible behavior). Addresses this: https://github.com/dms-vep/SARS-CoV-2_Delta_spike_DMS/issues/11

Incremented to version 2.3.