### PR TITLE
fix bug in wildtype heatmap plot introduced in 2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+2.4
+---
+- Fix bug introduced in version 2.3 that dropped wildtype sites if there were minimums set in ``slider_binding_range_kwargs`` to ``lineplot_and_heatmap``.
+
 2.3
 ---
 - ``lineplot_and_heatmap`` computes the limit for the heatmap range **after** applying the minimum filters specified in the filters. This avoids having the range determined by mutations that are never plotted, and so is sort of a bug fix (prior behavior wasn't strictly a bug, but did not give sensible behavior).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,8 +6,8 @@ Installation
 Unfortunately ``polyclonal`` cannot currently be installed from `PyPI <https://pypi.org/>`_.
 The reason is that ``polyclonal`` currently uses the `GitHub development version of altair <https://github.com/altair-viz/altair/discussions/2588>`_, which has to be installed from GitHub and `PyPI <https://pypi.org/>`_ does not allow GitHub dependencies.
 Therefore, for now you have to install ``polyclonal`` from GitHub.
-To do this for version 2.3 of ``polyclonal``, you would use this command::
+To do this for version 2.4 of ``polyclonal``, you would use this command::
 
-    pip install git+https://github.com/jbloomlab/polyclonal/@2.3#egg=polyclonal
+    pip install git+https://github.com/jbloomlab/polyclonal/@2.4#egg=polyclonal
 
 The source code for ``polyclonal`` is available on GitHub at https://github.com/jbloomlab/polyclonal.

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -31,7 +31,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "2.3"
+__version__ = "2.4"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -373,7 +373,10 @@ def lineplot_and_heatmap(
         slider_binding_range_kwargs = {}
     for col, col_kwargs in slider_binding_range_kwargs.items():
         if "min" in col_kwargs:
-            data_df = data_df[data_df[col] >= col_kwargs["min"]]
+            data_df = data_df[
+                (data_df[col] >= col_kwargs["min"])
+                | (data_df["wildtype"] == data_df["mutant"])
+            ]
 
     categories = data_df[category_col].unique().tolist()
     show_category_label = show_single_category_label or (len(categories) > 1)


### PR DESCRIPTION
In version 2.3, introduced a bug that when a min was specified for a slider range, the heatmap plots didn't show wildtype (https://github.com/dms-vep/dms-vep-pipeline/issues/88).

That bug is now fixed.

This becomes version 2.4.