### PR TITLE
fix assert statement in reg_similarity

### DIFF
--- a/polyclonal/polyclonal.py
+++ b/polyclonal/polyclonal.py
@@ -1504,7 +1504,7 @@ class Polyclonal:
                 for siteindex in self._binary_sites.values()
             ]
         )
-        assert site_norm.shape == (len(self.sites), len(self.epitopes))
+        assert site_norm.shape == (len(self._binary_sites.values()), len(self.epitopes))
         gram = site_norm.transpose() @ site_norm
         assert gram.shape == (len(self.epitopes), len(self.epitopes))
         inner_prod = gram * (1 - numpy.eye(*gram.shape))


### PR DESCRIPTION
This PR fixes an error that @caelanradford was getting with `_reg_similarity` when including reference sites. 
<img width="823" alt="Screen Shot 2022-10-20 at 4 16 10 PM" src="https://user-images.githubusercontent.com/36126324/197279494-88738cc0-b9d0-4188-be8f-ea835d6c0642.png">

The problem was the reference file contains sites not seen in the data. I changed the `assert` statement to check the number of sites seen in the data, not the reference file. @jbloom can you review and merge? Thanks!