### PR TITLE
use `altair` version 5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+5.1
+---
+- Update to using ``altair`` version 5.0.0rc1, which can be installed by `pip`. This also means for the first time ``polyclonal`` itself can be on PyPI, which changes installation instructions.
+
 5.0
 ---
 - Increase default ``reg_activity_weight`` from 1.0 to 2.0, note that this will change results relative to models fit with earlier versions with the old default weight.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,11 +3,12 @@ Installation
 
 ``polyclonal`` requires Python 3.8 or higher.
 
-Unfortunately ``polyclonal`` cannot currently be installed from `PyPI <https://pypi.org/>`_.
-The reason is that ``polyclonal`` currently uses the `GitHub development version of altair <https://github.com/altair-viz/altair/discussions/2588>`_, which has to be installed from GitHub and `PyPI <https://pypi.org/>`_ does not allow GitHub dependencies.
-Therefore, for now you have to install ``polyclonal`` from GitHub.
-To do this for version 5.0 of ``polyclonal``, you would use this command::
+To install the latest version, simply use ``pip`` to install from `PyPI <https://pypi.org/>`_ with::
+
+    pip install polyclonal
+
+The source code for ``polyclonal`` is available on GitHub at https://github.com/jbloomlab/polyclonal.
+If you want to install versions earlier than 5.1, you have to install from GitHub with commands like::
 
     pip install git+https://github.com/jbloomlab/polyclonal/@5.0#egg=polyclonal
 
-The source code for ``polyclonal`` is available on GitHub at https://github.com/jbloomlab/polyclonal.

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -31,7 +31,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "5.0"
+__version__ = "5.1"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,7 @@ setup(
     long_description=readme,
     license="GPLv3",
     install_requires=[
-        # https://stackoverflow.com/a/54793503
-        "altair @ git+https://github.com/altair-viz/altair@f8912bad75d4247ab726b639968b13315161660a",  # noqa: E501
+        "altair>=5.0.0rc1",
         "binarymap>=0.6",
         "biopython>=1.79",
         "frozendict>=2.0.7",


### PR DESCRIPTION
This becomes `polyclonal` version 5.1.

For the first time, can be installed via `pip` as now using `altair` version on PyPI.