### PR TITLE
Ensure that wildtype identity is always shown in heatmap tooltips even if mutation is filtered

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 ---
 - Add ``heatmap_lims_from_slider_init`` option to ``lineplot_and_heatmap`` so that by default heatmap range is set by data shown with initial slider stats. Set this option to ``False`` if you want old behavior for plot limits
 - Set default ``init_floor_at_zero`` for ``mut_icXX_plot`` to be ``True`` like for other plots.
+- Ensure that wildtype identity is always shown in heatmap tooltips even if mutation is filtered.
 
 6.6
 ---


### PR DESCRIPTION
Before it was possible for `df_to_merge` to end up yielding heatmap data where the wildtype was not showing up in tooltips but instead was NaN.

Fixes this issue: https://github.com/dms-vep/dms-vep-pipeline-3/issues/43