### PR TITLE
Added `rename_std` option to `lineplot_and_heatmaps`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+6.9
+---
+- Added ``rename_std`` option to ``lineplot_and_heatmaps``, which fixes a quasi-bug introduced in the ``rename_stat_col`` option by the changes in version 6.8.
+
 6.8
 ---
 - Add ``addtl_slider_stats_as_max`` to ``lineplot_and_heatmap``.

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -31,7 +31,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://research.fhcrc.org/bloom/en.html>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "6.8"
+__version__ = "6.9"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS


### PR DESCRIPTION
Fixes a quasi-bug introduced in the ``rename_stat_col`` option by the changes in version 6.8.