### PR TITLE
Fix bug in plotting `minimum max of <stat> at site slider`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on `Keep a Changelog <https://keepachangelog.com>`_.
 
+6.14
+----
+- Fix bug in ``plot.lineplot_and_heatmap`` where the ``minimum max of <stat> at site`` failed to keep only the top sites when the hide-not-filter option was being used. Addresses `this issue <https://github.com/dms-vep/dms-vep-pipeline-3/issues/107>`_.
+
 6.13
 ----
 - Fixed ``altair`` plots to work with ``numpy`` version 2, which caused problems in some cases apparently due to a data type conversion issue.

--- a/polyclonal/__init__.py
+++ b/polyclonal/__init__.py
@@ -31,7 +31,7 @@ It also imports the following alphabets:
 
 __author__ = "`the Bloom lab <https://jbloomlab.org>`_"
 __email__ = "jbloom@fredhutch.org"
-__version__ = "6.13"
+__version__ = "6.14"
 __url__ = "https://github.com/jbloomlab/polyclonal"
 
 from polyclonal.alphabets import AAS

--- a/polyclonal/plot.py
+++ b/polyclonal/plot.py
@@ -952,7 +952,11 @@ def lineplot_and_heatmap(
                 _stat_site_max="max(_stat_not_hidden)",
                 groupby=["site"],
             )
-        if slider_stat not in addtl_slider_stats_hide_not_filter:
+            base_chart = base_chart.transform_filter(
+                (alt.datum[slider_stat] >= (slider - 1e-6))  # round tol
+                | ~alt.expr.isFinite(alt.datum[slider_stat])  # do not filter null
+            )
+        elif slider_stat not in addtl_slider_stats_hide_not_filter:
             if slider_stat in addtl_slider_stats_as_max:
                 base_chart = base_chart.transform_filter(
                     (alt.datum[slider_stat] <= (slider + 1e-6))  # round tol


### PR DESCRIPTION
Fix bug in `plot.lineplot_and_heatmap` where the `minimum max of <stat> at site` failed to keep only the top sites when hide not filter option was being used.

Addresses [this issues](https://github.com/dms-vep/dms-vep-pipeline-3/issues/107).